### PR TITLE
fix: deduplicate certificates by course_id to prevent duplicate display

### DIFF
--- a/frontend/app/base/composables/useUserStats.ts
+++ b/frontend/app/base/composables/useUserStats.ts
@@ -79,8 +79,15 @@ export const useUserStats = () => {
   const getCertificateCount = async (): Promise<number> => {
     try {
       const certificates = await getUserCertificates()
-      // Count both ISSUED and PENDING certificates
-      return certificates.filter(cert => cert.status === 'ISSUED' || cert.status === 'PENDING').length
+      
+      // Deduplicate by course_id and count unique certificates
+      const uniqueCourseIds = new Set(
+        certificates
+          .filter(cert => cert.status === 'ISSUED' || cert.status === 'PENDING')
+          .map(cert => cert.course_id)
+      )
+      
+      return uniqueCourseIds.size
     } catch (error) {
       console.error('Failed to fetch certificate count:', error)
       return 0
@@ -216,10 +223,20 @@ export const useUserStats = () => {
     try {
       const certificates = await getUserCertificates()
       
-      return certificates
-        .filter(cert => cert.status === 'ISSUED' || cert.status === 'PENDING') // Include both ISSUED and PENDING
+      // Deduplicate certificates by course_id (keep only the most recent one per course)
+      const uniqueCertificates = certificates
+        .filter(cert => cert.status === 'ISSUED' || cert.status === 'PENDING')
         .sort((a, b) => new Date(b.issued_at).getTime() - new Date(a.issued_at).getTime())
-        .slice(0, 3) // Get only the 3 most recent
+        .reduce((acc, cert) => {
+          // Only add if we haven't seen this course_id yet
+          if (!acc.some(c => c.course_id === cert.course_id)) {
+            acc.push(cert)
+          }
+          return acc
+        }, [] as typeof certificates)
+      
+      return uniqueCertificates
+        .slice(0, 3) // Get only the 3 most recent unique certificates
         .map(cert => ({
           id: cert.id,
           courseName: cert.course?.title || 'Unknown Course',


### PR DESCRIPTION
- Add deduplication logic in getRecentCertificates() to show only one certificate per course
- Fix getCertificateCount() to count unique courses instead of all certificates
- Keep most recent certificate when duplicates exist for same course